### PR TITLE
fix abnormal spike  : Init res state to 1.0

### DIFF
--- a/came_pytorch/CAME.py
+++ b/came_pytorch/CAME.py
@@ -102,8 +102,8 @@ class CAME(torch.optim.Optimizer):
                             grad_shape[:-2] + grad_shape[-1:]
                         ).type_as(grad)
 
-                        state["exp_avg_res_row"] = torch.zeros(grad_shape[:-1]).type_as(grad)
-                        state["exp_avg_res_col"] = torch.zeros(
+                        state["exp_avg_res_row"] = torch.ones(grad_shape[:-1]).type_as(grad)
+                        state["exp_avg_res_col"] = torch.ones(
                             grad_shape[:-2] + grad_shape[-1:]
                         ).type_as(grad)
                     else:

--- a/came_pytorch/CAME.py
+++ b/came_pytorch/CAME.py
@@ -60,7 +60,7 @@ class CAME(torch.optim.Optimizer):
 
     def _approx_sq_grad(self, exp_avg_sq_row, exp_avg_sq_col):
         r_factor = (
-            (exp_avg_sq_row / exp_avg_sq_row.mean(dim=-1, keepdim=True))
+            (exp_avg_sq_row / exp_avg_sq_row.mean(dim=-1, keepdim=True).add_(self.param_groups[0]["eps"][1]))
             .rsqrt_()
             .unsqueeze(-1)
         )


### PR DESCRIPTION
Hello.

This Pull Request addresses an instability issue during the initial steps of training.

## Problem

The current initialization of `exp_avg_res_row` and `exp_avg_res_col` to zero causes an **abnormally large spike in `res_approx`** at step 0 (e.g. res_approx.mean().items()=100000) , resulting in excessively large parameter updates.

This large initial value leads to two problems:

1. Model Instability 
Certain layers may sustain damage.
e.g., resulting in unexpected artifacts or unnatural color shifts in the output.
2. Persistent Abnormality
If the user utilizes a high `beta[2]` value (e.g., `> 0.99`), this initial abnormal value persists, severely hindering the optimizer's ability to return to a normal state.

## Changing point
Non-zero initial value is required to prevent this immediate instability. This PR sets the initial value of the `res` related states to 1.0.

This change ensures that training starts from a neutral, stable state, effectively preventing catastrophic model failure at the start of the run.